### PR TITLE
Create additional patchers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,42 @@ be saved for later restoration.  For instance::
     	}
     }
 
+``SetEnv()`` and ``UnsetEnv()``
+-------------------------------
+
+The ``SetEnv()`` and ``UnsetEnv()`` functions create an instance of an
+``EnvPatcher`` struct, which implements ``Patcher``.  The values from
+``SetEnv()`` and ``UnsetEnv()`` work to ensure that the system
+environment variables match a desired test environment, e.g., that a
+particular environment variable is set to a desired value while
+another one is not set at all.  For instance::
+
+    func DoSomething() error {
+    	filename, ok := os.LookupEnv("FILENAME")
+    	if !ok {
+    		filename := "some-filename"
+    	}
+
+    	data, err := io.ReadFile(filename)
+    	if err != nil {
+    		return err
+    	}
+
+    	// Do something...
+
+    	return nil
+    }
+
+    func TestDoSomething(t *testing.T) {
+    	defer UnsetEnv("FILENAME").Install().Restore()
+
+    	err := DoSomething()
+
+    	if err != nil {
+    		t.Fail("non-nil error!")
+    	}
+    }
+
 ``NewPatchMaster()``
 --------------------
 

--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,40 @@ used::
     	}
     }
 
+``Log()``
+---------
+
+The ``Log()`` function creates an instance of a ``LogPatcher`` struct,
+which implements ``Patcher``.  The ``Log()`` function is called with
+an ``io.Writer`` to which the output of the default logger from the
+``log`` package should be redirected while the patch is active; when
+the ``Patcher`` is installed, all output to the default logger will be
+redirected to that ``io.Writer`` and the original ``io.Writer`` will
+be saved for later restoration.  For instance::
+
+    func DoSomething(filename string) error {
+    	data, err := io.ReadFile(filename)
+    	if err != nil {
+    		log.Printf("Error reading file")
+    		return err
+    	}
+
+    	// Do something...
+
+    	return nil
+    }
+
+    func TestDoSomething(t *testing.T) {
+    	logStream := &bytes.Buffer{}
+    	defer Log(logStream).Install().Restore()
+
+    	err := DoSomething("some-filename")
+
+    	if logStream.String() != "Error reading file" {
+    		t.Fail("failed to log!")
+    	}
+    }
+
 ``NewPatchMaster()``
 --------------------
 

--- a/env.go
+++ b/env.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2020 Kevin L. Mitchell
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you
+// may not use this file except in compliance with the License.  You
+// may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+
+package patcher
+
+import "os"
+
+// EnvPatcher is a patcher that, given an environment variable name,
+// will set or unset that environment variable.
+type EnvPatcher struct {
+	name     string
+	value    *string
+	original *string
+	applied  bool
+}
+
+// Patch points for testing the routines in this file.
+var (
+	setenv    func(string, string) error  = os.Setenv
+	lookupenv func(string) (string, bool) = os.LookupEnv
+	unsetenv  func(string) error          = os.Unsetenv
+)
+
+// setEnv is a helper for the EnvPatcher that sets or unsets an
+// environment variable depending on whether the value pointer is nil
+// or a string.  It will panic if there is an error.
+func setEnv(name string, value *string) {
+	var err error
+	if value == nil {
+		// Only unset if it's set
+		if _, ok := lookupenv(name); ok {
+			err = unsetenv(name)
+		}
+	} else {
+		err = setenv(name, *value)
+	}
+
+	// If there was an error setting or unsetting the environment
+	// variable, panic
+	if err != nil {
+		panic(err)
+	}
+}
+
+// SetEnv constructs an EnvPatcher, storing the desired value of the
+// specified environment variable.  It could be used in a test
+// function like so:
+//
+//	func TestDoSomething(t *testing.T) {
+//		defer SetEnv("VARNAME", "value").Install().Restore()
+//
+//		err := DoSomething("some-filename")
+//
+//		if err != nil {
+//			t.Fail("non-nil error!")
+//		}
+//	}
+func SetEnv(name, value string) *EnvPatcher {
+	return &EnvPatcher{
+		name:  name,
+		value: &value,
+	}
+}
+
+// UnsetEnv constructs an EnvPatcher.  The specified environment
+// variable will be unset when the patch is installed.  It could be
+// used in a test function like so:
+//
+//	func TestDoSomething(t *testing.T) {
+//		defer UnsetEnv("FILENAME").Install().Restore()
+//
+//		err := DoSomething()
+//
+//		if err != nil {
+//			t.Fail("non-nil error!")
+//		}
+//	}
+func UnsetEnv(name string) *EnvPatcher {
+	return &EnvPatcher{
+		name: name,
+	}
+}
+
+// Install installs the patch.  It should store metadata sufficient to
+// allow Restore to restore the original data.  This method must be
+// idempotent.
+func (ep *EnvPatcher) Install() Patcher {
+	// Be idempotent
+	if ep.applied {
+		return ep
+	}
+
+	// Save the current value of the environment variable
+	if value, ok := lookupenv(ep.name); ok {
+		ep.original = &value
+	} else {
+		ep.original = nil
+	}
+
+	// Set the environment variable to the desired value
+	setEnv(ep.name, ep.value)
+	ep.applied = true
+
+	return ep
+}
+
+// Restore uses the metadata stored by Install to restore the patch to
+// its original value.  This method must be idempotent.
+func (ep *EnvPatcher) Restore() Patcher {
+	// Be idempotent
+	if !ep.applied {
+		return ep
+	}
+
+	// Restore the environment variable to the original value
+	setEnv(ep.name, ep.original)
+	ep.applied = false
+
+	return ep
+}

--- a/env_test.go
+++ b/env_test.go
@@ -1,0 +1,384 @@
+// Copyright (c) 2020 Kevin L. Mitchell
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you
+// may not use this file except in compliance with the License.  You
+// may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+
+package patcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvPatcherImplementsPatcher(t *testing.T) {
+	assert.Implements(t, (*Patcher)(nil), &EnvPatcher{})
+}
+
+func TestInternalSetEnvUnsetExists(t *testing.T) {
+	setenvCalled := false
+	lookupenvCalled := false
+	unsetenvCalled := false
+	defer NewPatchMaster(
+		SetVar(&setenv, func(n, v string) error {
+			assert.Equal(t, "ENV", n)
+			assert.Equal(t, "value", v)
+			setenvCalled = true
+			return nil
+		}),
+		SetVar(&lookupenv, func(n string) (string, bool) {
+			assert.Equal(t, "ENV", n)
+			lookupenvCalled = true
+			return "", true
+		}),
+		SetVar(&unsetenv, func(n string) error {
+			assert.Equal(t, "ENV", n)
+			unsetenvCalled = true
+			return nil
+		}),
+	).Install().Restore()
+
+	setEnv("ENV", nil)
+
+	assert.False(t, setenvCalled)
+	assert.True(t, lookupenvCalled)
+	assert.True(t, unsetenvCalled)
+}
+
+func TestInternalSetEnvUnsetMissing(t *testing.T) {
+	setenvCalled := false
+	lookupenvCalled := false
+	unsetenvCalled := false
+	defer NewPatchMaster(
+		SetVar(&setenv, func(n, v string) error {
+			assert.Equal(t, "ENV", n)
+			assert.Equal(t, "value", v)
+			setenvCalled = true
+			return nil
+		}),
+		SetVar(&lookupenv, func(n string) (string, bool) {
+			assert.Equal(t, "ENV", n)
+			lookupenvCalled = true
+			return "", false
+		}),
+		SetVar(&unsetenv, func(n string) error {
+			assert.Equal(t, "ENV", n)
+			unsetenvCalled = true
+			return nil
+		}),
+	).Install().Restore()
+
+	setEnv("ENV", nil)
+
+	assert.False(t, setenvCalled)
+	assert.True(t, lookupenvCalled)
+	assert.False(t, unsetenvCalled)
+}
+
+func TestInternalSetEnvUnsetFails(t *testing.T) {
+	setenvCalled := false
+	lookupenvCalled := false
+	unsetenvCalled := false
+	defer NewPatchMaster(
+		SetVar(&setenv, func(n, v string) error {
+			assert.Equal(t, "ENV", n)
+			assert.Equal(t, "value", v)
+			setenvCalled = true
+			return nil
+		}),
+		SetVar(&lookupenv, func(n string) (string, bool) {
+			assert.Equal(t, "ENV", n)
+			lookupenvCalled = true
+			return "", true
+		}),
+		SetVar(&unsetenv, func(n string) error {
+			assert.Equal(t, "ENV", n)
+			unsetenvCalled = true
+			return assert.AnError
+		}),
+	).Install().Restore()
+
+	assert.PanicsWithValue(t, assert.AnError, func() { setEnv("ENV", nil) })
+	assert.False(t, setenvCalled)
+	assert.True(t, lookupenvCalled)
+	assert.True(t, unsetenvCalled)
+}
+
+func TestInternalSetEnvSetBase(t *testing.T) {
+	setenvCalled := false
+	lookupenvCalled := false
+	unsetenvCalled := false
+	defer NewPatchMaster(
+		SetVar(&setenv, func(n, v string) error {
+			assert.Equal(t, "ENV", n)
+			assert.Equal(t, "value", v)
+			setenvCalled = true
+			return nil
+		}),
+		SetVar(&lookupenv, func(n string) (string, bool) {
+			assert.Equal(t, "ENV", n)
+			lookupenvCalled = true
+			return "", true
+		}),
+		SetVar(&unsetenv, func(n string) error {
+			assert.Equal(t, "ENV", n)
+			unsetenvCalled = true
+			return nil
+		}),
+	).Install().Restore()
+	value := "value"
+
+	setEnv("ENV", &value)
+
+	assert.True(t, setenvCalled)
+	assert.False(t, lookupenvCalled)
+	assert.False(t, unsetenvCalled)
+}
+
+func TestInternalSetEnvSetFails(t *testing.T) {
+	setenvCalled := false
+	lookupenvCalled := false
+	unsetenvCalled := false
+	defer NewPatchMaster(
+		SetVar(&setenv, func(n, v string) error {
+			assert.Equal(t, "ENV", n)
+			assert.Equal(t, "value", v)
+			setenvCalled = true
+			return assert.AnError
+		}),
+		SetVar(&lookupenv, func(n string) (string, bool) {
+			assert.Equal(t, "ENV", n)
+			lookupenvCalled = true
+			return "", true
+		}),
+		SetVar(&unsetenv, func(n string) error {
+			assert.Equal(t, "ENV", n)
+			unsetenvCalled = true
+			return nil
+		}),
+	).Install().Restore()
+	value := "value"
+
+	assert.PanicsWithValue(t, assert.AnError, func() { setEnv("ENV", &value) })
+	assert.True(t, setenvCalled)
+	assert.False(t, lookupenvCalled)
+	assert.False(t, unsetenvCalled)
+}
+
+func TestSetEnv(t *testing.T) {
+	result := SetEnv("ENV", "value")
+
+	assert.Equal(t, "ENV", result.name)
+	assert.Equal(t, "value", *result.value)
+	assert.Nil(t, result.original)
+	assert.False(t, result.applied)
+}
+
+func TestUnsetEnv(t *testing.T) {
+	result := UnsetEnv("ENV")
+
+	assert.Equal(t, "ENV", result.name)
+	assert.Nil(t, result.value)
+	assert.Nil(t, result.original)
+	assert.False(t, result.applied)
+}
+
+func TestEnvPatcherInstallExists(t *testing.T) {
+	setenvCalled := false
+	lookupenvCalled := false
+	unsetenvCalled := false
+	defer NewPatchMaster(
+		SetVar(&setenv, func(n, v string) error {
+			assert.Equal(t, "ENV", n)
+			assert.Equal(t, "value", v)
+			setenvCalled = true
+			return nil
+		}),
+		SetVar(&lookupenv, func(n string) (string, bool) {
+			assert.Equal(t, "ENV", n)
+			lookupenvCalled = true
+			return "original", true
+		}),
+		SetVar(&unsetenv, func(n string) error {
+			assert.Equal(t, "ENV", n)
+			unsetenvCalled = true
+			return nil
+		}),
+	).Install().Restore()
+	value := "value"
+	obj := &EnvPatcher{
+		name:  "ENV",
+		value: &value,
+	}
+
+	result := obj.Install()
+
+	assert.Same(t, obj, result)
+	assert.Equal(t, "original", *obj.original)
+	assert.True(t, obj.applied)
+	assert.True(t, setenvCalled)
+	assert.True(t, lookupenvCalled)
+	assert.False(t, unsetenvCalled)
+}
+
+func TestEnvPatcherInstallMissing(t *testing.T) {
+	setenvCalled := false
+	lookupenvCalled := false
+	unsetenvCalled := false
+	defer NewPatchMaster(
+		SetVar(&setenv, func(n, v string) error {
+			assert.Equal(t, "ENV", n)
+			assert.Equal(t, "value", v)
+			setenvCalled = true
+			return nil
+		}),
+		SetVar(&lookupenv, func(n string) (string, bool) {
+			assert.Equal(t, "ENV", n)
+			lookupenvCalled = true
+			return "", false
+		}),
+		SetVar(&unsetenv, func(n string) error {
+			assert.Equal(t, "ENV", n)
+			unsetenvCalled = true
+			return nil
+		}),
+	).Install().Restore()
+	value := "value"
+	obj := &EnvPatcher{
+		name:  "ENV",
+		value: &value,
+	}
+
+	result := obj.Install()
+
+	assert.Same(t, obj, result)
+	assert.Nil(t, obj.original)
+	assert.True(t, obj.applied)
+	assert.True(t, setenvCalled)
+	assert.True(t, lookupenvCalled)
+	assert.False(t, unsetenvCalled)
+}
+
+func TestEnvPatcherInstallIdempotent(t *testing.T) {
+	setenvCalled := false
+	lookupenvCalled := false
+	unsetenvCalled := false
+	defer NewPatchMaster(
+		SetVar(&setenv, func(n, v string) error {
+			assert.Equal(t, "ENV", n)
+			assert.Equal(t, "value", v)
+			setenvCalled = true
+			return nil
+		}),
+		SetVar(&lookupenv, func(n string) (string, bool) {
+			assert.Equal(t, "ENV", n)
+			lookupenvCalled = true
+			return "original", true
+		}),
+		SetVar(&unsetenv, func(n string) error {
+			assert.Equal(t, "ENV", n)
+			unsetenvCalled = true
+			return nil
+		}),
+	).Install().Restore()
+	value := "value"
+	original := "original"
+	obj := &EnvPatcher{
+		name:     "ENV",
+		value:    &value,
+		original: &original,
+		applied:  true,
+	}
+
+	result := obj.Install()
+
+	assert.Same(t, obj, result)
+	assert.True(t, obj.applied)
+	assert.False(t, setenvCalled)
+	assert.False(t, lookupenvCalled)
+	assert.False(t, unsetenvCalled)
+}
+
+func TestEnvPatcherRestoreBase(t *testing.T) {
+	setenvCalled := false
+	lookupenvCalled := false
+	unsetenvCalled := false
+	defer NewPatchMaster(
+		SetVar(&setenv, func(n, v string) error {
+			assert.Equal(t, "ENV", n)
+			assert.Equal(t, "original", v)
+			setenvCalled = true
+			return nil
+		}),
+		SetVar(&lookupenv, func(n string) (string, bool) {
+			assert.Equal(t, "ENV", n)
+			lookupenvCalled = true
+			return "original", true
+		}),
+		SetVar(&unsetenv, func(n string) error {
+			assert.Equal(t, "ENV", n)
+			unsetenvCalled = true
+			return nil
+		}),
+	).Install().Restore()
+	original := "original"
+	obj := &EnvPatcher{
+		name:     "ENV",
+		original: &original,
+		applied:  true,
+	}
+
+	result := obj.Restore()
+
+	assert.Same(t, obj, result)
+	assert.False(t, obj.applied)
+	assert.True(t, setenvCalled)
+	assert.False(t, lookupenvCalled)
+	assert.False(t, unsetenvCalled)
+}
+
+func TestEnvPatcherRestoreIdempotent(t *testing.T) {
+	setenvCalled := false
+	lookupenvCalled := false
+	unsetenvCalled := false
+	defer NewPatchMaster(
+		SetVar(&setenv, func(n, v string) error {
+			assert.Equal(t, "ENV", n)
+			assert.Equal(t, "original", v)
+			setenvCalled = true
+			return nil
+		}),
+		SetVar(&lookupenv, func(n string) (string, bool) {
+			assert.Equal(t, "ENV", n)
+			lookupenvCalled = true
+			return "original", true
+		}),
+		SetVar(&unsetenv, func(n string) error {
+			assert.Equal(t, "ENV", n)
+			unsetenvCalled = true
+			return nil
+		}),
+	).Install().Restore()
+	original := "original"
+	obj := &EnvPatcher{
+		name:     "ENV",
+		original: &original,
+	}
+
+	result := obj.Restore()
+
+	assert.Same(t, obj, result)
+	assert.False(t, obj.applied)
+	assert.False(t, setenvCalled)
+	assert.False(t, lookupenvCalled)
+	assert.False(t, unsetenvCalled)
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -12,12 +12,13 @@
 // implied.  See the License for the specific language governing
 // permissions and limitations under the License.
 
-// Patcher is a testing tool intended to aid in the construction of
-// tests which "patch" the source in some fashion.  This is not monkey
-// patching, like is performed with dynamic languages like Python;
-// Patcher requires that the source code be written with the patching
-// in mind.  For instance, a particular function called by the source
-// may be assigned to a variable, then that variable used in the call.
+// Package patcher is a testing tool intended to aid in the
+// construction of tests which "patch" the source in some fashion.
+// This is not monkey patching, like is performed with dynamic
+// languages like Python; Patcher requires that the source code be
+// written with the patching in mind.  For instance, a particular
+// function called by the source may be assigned to a variable, then
+// that variable used in the call.
 //
 // The primary API in this package is the Patcher interface.
 // Something that implements the Patcher interface has two idempotent
@@ -29,7 +30,6 @@
 // a Patcher; most users of this package will not find this type
 // useful.  The more useful Patcher implementations are created with
 // SetVar and NewPatchMaster.
-
 package patcher
 
 // Patcher is an interface for patchers.  Patchers have Install and

--- a/log.go
+++ b/log.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2020 Kevin L. Mitchell
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you
+// may not use this file except in compliance with the License.  You
+// may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+
+package patcher
+
+import (
+	"io"
+	"log"
+)
+
+// LogPatcher is a patcher that, given a io.Writer, will update the
+// output of the default logger in the log package.
+type LogPatcher struct {
+	value    io.Writer
+	original io.Writer
+	applied  bool
+}
+
+// Log constructs a LogPatcher, storing the desired io.Writer to use
+// with the default logger.  It could be used in a test function like
+// so:
+//
+//	func TestDoSomething(t *testing.T) {
+//		logStream := &bytes.Buffer{}
+//		defer Log(logStream).Install().Restore()
+//
+//		err := DoSomething("some-filename")
+//
+//		if logStream.String() != "Error reading file" {
+//			t.Fail("failed to log!")
+//		}
+//	}
+func Log(value io.Writer) *LogPatcher {
+	return &LogPatcher{
+		value: value,
+	}
+}
+
+// Install installs the patch.  It should store metadata sufficient to
+// allow Restore to restore the original data.  This method must be
+// idempotent.
+func (lp *LogPatcher) Install() Patcher {
+	// Be idempotent
+	if lp.applied {
+		return lp
+	}
+
+	// Save the current value of the log output
+	lp.original = log.Writer()
+
+	// Set the patch value
+	log.SetOutput(lp.value)
+	lp.applied = true
+
+	return lp
+}
+
+// Restore uses the metadata stored by Install to restore the patch to
+// its original value.  This method must be idempotent.
+func (lp *LogPatcher) Restore() Patcher {
+	// Be idempotent
+	if !lp.applied {
+		return lp
+	}
+
+	// Restore the original log output
+	log.SetOutput(lp.original)
+	lp.applied = false
+
+	return lp
+}

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2020 Kevin L. Mitchell
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you
+// may not use this file except in compliance with the License.  You
+// may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+
+package patcher
+
+import (
+	"bytes"
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogPatcherImplementsPatcher(t *testing.T) {
+	assert.Implements(t, (*Patcher)(nil), &LogPatcher{})
+}
+
+func TestLog(t *testing.T) {
+	value := &bytes.Buffer{}
+
+	lp := Log(value)
+
+	assert.Equal(t, &LogPatcher{
+		value: value,
+	}, lp)
+}
+
+func TestLogPatcherInstallBase(t *testing.T) {
+	value := &bytes.Buffer{}
+	original := log.Writer()
+	defer func() { log.SetOutput(original) }()
+	lp := &LogPatcher{
+		value: value,
+	}
+
+	result := lp.Install()
+
+	assert.Same(t, lp, result)
+	assert.Same(t, original, lp.original)
+	assert.Same(t, value, log.Writer())
+	assert.True(t, lp.applied)
+}
+
+func TestLogPatcherInstallIdempotent(t *testing.T) {
+	value := &bytes.Buffer{}
+	original := log.Writer()
+	defer func() { log.SetOutput(original) }()
+	lp := &LogPatcher{
+		value:   value,
+		applied: true,
+	}
+
+	result := lp.Install()
+
+	assert.Same(t, lp, result)
+	assert.Nil(t, lp.original)
+	assert.Same(t, original, log.Writer())
+	assert.True(t, lp.applied)
+}
+
+func TestLogPatcherRestoreBase(t *testing.T) {
+	value := &bytes.Buffer{}
+	original := log.Writer()
+	defer func() { log.SetOutput(original) }()
+	lp := &LogPatcher{
+		value:    original,
+		original: value,
+		applied:  true,
+	}
+
+	result := lp.Restore()
+
+	assert.Same(t, lp, result)
+	assert.Same(t, value, log.Writer())
+	assert.False(t, lp.applied)
+}
+
+func TestLogPatcherRestoreIdempotent(t *testing.T) {
+	value := &bytes.Buffer{}
+	original := log.Writer()
+	defer func() { log.SetOutput(original) }()
+	lp := &LogPatcher{
+		original: value,
+	}
+
+	result := lp.Restore()
+
+	assert.Same(t, lp, result)
+	assert.Same(t, original, log.Writer())
+	assert.False(t, lp.applied)
+}


### PR DESCRIPTION
This PR includes two new patchers, one for the system logger and the other for environment variables.  It also fixes a minor problem with the package description that was causing it to not be rendered in godoc.